### PR TITLE
Load improvements: verbose logging, doc count feedback, and arg fix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,16 +3,16 @@ node {
         checkout scm
 
         //parent wrapper image
-        docker.image('mongo:3.6.10').withRun('-e "MONGO_INITDB_ROOT_USERNAME=root" -e "MONGO_INITDB_ROOT_PASSWORD=password"') { c ->
+        docker.image('mongo:8.3.2').withRun('-e "MONGO_INITDB_ROOT_USERNAME=root" -e "MONGO_INITDB_ROOT_PASSWORD=password"') { c ->
 
             stage("spin up db") {
                 //get access to mongoshell methods
-                docker.image('mongo:3.6.10').inside("--link ${c.id}") {
+                docker.image('mongo:8.3.2').inside("--link ${c.id}") {
 
                     sh "env"
 
                     //wait until mongodb is initialized
-                    sh "bash -c 'COUNTER=0 && until mongo mongodb://root:password@${c.id}:27017/integration?authSource=admin --eval \"print(\\\"waited for connection\\\")\"; do sleep 1; let \"COUNTER++\"; echo \$COUNTER; if [ \$COUNTER -eq 15 ]; then exit 1 ; fi; done'"
+                    sh "bash -c 'COUNTER=0 && until mongo mongodb://root:password@${c.id}:27017/integration?authSource=admin --eval \"print(\\\"waited for connection\\\")\"; do sleep 1; let \"COUNTER++\"; echo \$COUNTER; if [ \$COUNTER -eq 10 ]; then exit 1 ; fi; done'"
 
                     sh "echo loading test data..."
 

--- a/MATCHENGINE_DATA_REFERENCE.md
+++ b/MATCHENGINE_DATA_REFERENCE.md
@@ -1,0 +1,421 @@
+# MatchEngine Data Reference
+
+## 1. Reference Data (Patients)
+
+### Source
+- **MongoDB database:** `integration` (tests) or your production db
+- **Collection:** `clinical`
+- **Loaded from:** `matchengine/tests/data/integration_data/clinical.bson.gz` (test data)
+
+### Clinical Document Fields
+
+| Field | Description |
+|---|---|
+| `SAMPLE_ID` | Primary patient/sample identifier (used as join key) |
+| `MRN` | Medical record number |
+| `GENDER` | Patient gender |
+| `BIRTH_DATE` | Date of birth (datetime) |
+| `BIRTH_DATE_INT` | Birth date as integer (YYYYMMDD - 1) — used for age range queries |
+| `ONCOTREE_PRIMARY_DIAGNOSIS_NAME` | Cancer diagnosis using OncoTree terminology |
+| `VITAL_STATUS` | `"alive"` or `"deceased"` |
+| `REPORT_DATE` | Date of genomic report |
+| `TUMOR_MUTATIONAL_BURDEN_PER_MEGABASE` | TMB value (used for TMB-based trial matching) |
+| `MMR_STATUS` | Mismatch repair status |
+
+### Genomic Document Fields
+- **Collection:** `genomic`
+- **Join field:** `CLINICAL_ID` → `clinical._id`
+- **Loaded from:** `matchengine/tests/data/integration_data/genomic.bson.gz`
+
+| Field | Description |
+|---|---|
+| `CLINICAL_ID` | Foreign key back to `clinical._id` |
+| `SAMPLE_ID` | Sample identifier |
+| `TRUE_HUGO_SYMBOL` | Gene name (e.g. `EGFR`, `KRAS`) |
+| `TRUE_PROTEIN_CHANGE` | Protein-level change (e.g. `p.E746_A750del`) |
+| `TRUE_CDNA_CHANGE` | cDNA-level change |
+| `TRUE_VARIANT_CLASSIFICATION` | Variant class (e.g. `In_Frame_Del`, `Missense_Mutation`) |
+| `VARIANT_CATEGORY` | High-level category: `MUTATION`, `CNV`, `SV` |
+| `CNV_CALL` | Copy number call (e.g. `High level amplification`) |
+| `TRUE_TRANSCRIPT_EXON` | Exon number |
+| `WILDTYPE` | Boolean — whether this is a wildtype record |
+| `ALLELE_FRACTION` | Variant allele fraction |
+| `REFERENCE_ALLELE` | Reference allele |
+| `TIER` | Variant tier (1–4) |
+| `CHROMOSOME` | Chromosome |
+| `POSITION` | Genomic position |
+| `ACTIONABILITY` | Actionability annotation |
+| `MMR_STATUS` | MMR/MSI status on the genomic record |
+| `APOBEC_STATUS` | APOBEC mutational signature |
+| `POLE_STATUS` | POLE mutational signature |
+| `TABACCO_STATUS` | Tobacco mutational signature |
+| `TEMOZOLOMIDE_STATUS` | Temozolomide mutational signature |
+| `UVA_STATUS` | UV mutational signature |
+| `FUSION_PARTNER_HUGO_SYMBOL` | Second gene in a fusion |
+| `LEFT_PARTNER_GENE` / `RIGHT_PARTNER_GENE` | Structural variant partners |
+| `STRUCTURAL_VARIANT_COMMENT` | Free-text SV description (used for unstructured SV matching) |
+| `STRUCTURAL_VARIANT_TYPE` | SV type |
+| `STRUCTURED_SV` | Boolean — whether SV has structured data |
+
+---
+
+## 2. Query Data (Clinical Trials)
+
+### Source
+- **MongoDB collection:** `trial`
+- **Source files (test):** `matchengine/tests/data/integration_trials/*.json`
+- **Trial identifier:** `protocol_no`
+
+### Trial Document Structure (CTML)
+
+Trials are written in **CTML (Clinical Trial Markup Language)** — a nested JSON schema.
+
+```
+trial
+└── protocol_no          # e.g. "10-002"
+└── status               # e.g. "open to accrual"
+└── treatment_list
+    └── step[]
+        ├── step_code
+        ├── step_internal_id
+        ├── match[]          ← step-level eligibility criteria
+        └── arm[]
+            ├── arm_code
+            ├── arm_internal_id
+            ├── arm_suspended
+            ├── match[]      ← arm-level eligibility criteria (most specific)
+            └── dose_level[]
+                ├── level_code
+                ├── level_internal_id
+                ├── level_suspended
+                └── match[]  ← dose-level criteria
+```
+
+### CTML Match Block Structure
+
+Each `match` block is a tree of `and`/`or` nodes containing `clinical` and `genomic` leaf criteria:
+
+```json
+{
+  "and": [
+    {
+      "genomic": {
+        "hugo_symbol": "EGFR",
+        "variant_classification": "In_Frame_Del",
+        "variant_category": "Mutation"
+      }
+    },
+    {
+      "clinical": {
+        "age_numerical": ">=18",
+        "oncotree_primary_diagnosis": "Non-Small Cell Lung Cancer"
+      }
+    }
+  ]
+}
+```
+
+### Integration Test Trials
+
+| File | Protocol | Description |
+|---|---|---|
+| `all_open.json` | 10-002 | EGFR In_Frame_Del, NSCLC arm |
+| `all_closed.json` | — | All arms/steps closed |
+| `all_closed_trial_closed.json` | — | Entire trial closed |
+| `tmb.json` | 10-003 | TMB-based matching |
+| `signatures.json` | — | Mutational signature matching |
+| `structured_sv.json` | — | Structured SV matching |
+| `unstructured_sv.json` | — | Free-text SV comment matching |
+| `wildcard_protein_found.json` | 10-007 | Wildcard protein change matching |
+| `wildcard_protein_not_found.json` | — | Wildcard negative test |
+| `older_than_18.json` | — | Age criteria test |
+| `younger_than_18.json` | — | Age criteria test |
+| `closed_dose.json` | — | Dose level closed |
+| `closed_step_arm.json` | — | Step/arm closed |
+| `run_log_*.json` | — | Run log / incremental update tests |
+
+---
+
+## 3. Matching Criteria Configuration
+
+### Config File
+**`matchengine/config/dfci_config.json`**
+
+This file defines **how CTML trial keys map to patient document fields** and is the central configuration for what gets matched and how.
+
+### CTML → Patient Field Mappings
+
+#### Clinical Criteria (`ctml_collection_mappings.clinical.trial_key_mappings`)
+
+| CTML Key | Patient Field | Transform |
+|---|---|---|
+| `AGE_NUMERICAL` | `BIRTH_DATE_INT` | `age_range_to_date_int_query` — converts age expression (e.g. `>=18`) to a date integer range |
+| `ONCOTREE_PRIMARY_DIAGNOSIS` | `ONCOTREE_PRIMARY_DIAGNOSIS_NAME` | `external_file_mapping` via `matchengine/ref/oncotree_mapping.json` — expands a diagnosis name to all matching OncoTree subtypes |
+| `GENDER` | `GENDER` | Direct match (`nomap`) |
+| `TMB_NUMERICAL` | `TUMOR_MUTATIONAL_BURDEN_PER_MEGABASE` | `tmb_range_to_query` — converts expression to numeric range query |
+| `HER2_STATUS` | *(ignored)* | — |
+| `PR_STATUS` | *(ignored)* | — |
+| `ER_STATUS` | *(ignored)* | — |
+| `DISEASE_STATUS` | *(ignored)* | — |
+
+#### Genomic Criteria (`ctml_collection_mappings.genomic.trial_key_mappings`)
+
+| CTML Key | Patient Field | Transform |
+|---|---|---|
+| `HUGO_SYMBOL` | `TRUE_HUGO_SYMBOL` | Direct match |
+| `EXON` | `TRUE_TRANSCRIPT_EXON` | Direct match |
+| `PROTEIN_CHANGE` | `TRUE_PROTEIN_CHANGE` | Direct match |
+| `WILDCARD_PROTEIN_CHANGE` | `TRUE_PROTEIN_CHANGE` | `wildcard_regex` — supports `p.V600?` style patterns |
+| `VARIANT_CLASSIFICATION` | `TRUE_VARIANT_CLASSIFICATION` | Direct match |
+| `VARIANT_CATEGORY` | `VARIANT_CATEGORY` | `variant_category_map` — maps CTML values to patient vocab |
+| `CNV_CALL` | `CNV_CALL` | `cnv_map` |
+| `WILDTYPE` | `WILDTYPE` | Direct match |
+| `MMR_STATUS` | `MMR_STATUS` | `mmr_ms_map` |
+| `MS_STATUS` | `MMR_STATUS` | `mmr_ms_map` |
+| `APOBEC_SIGNATURE` | `APOBEC_STATUS` | Direct match |
+| `POLE_SIGNATURE` | `POLE_STATUS` | Direct match |
+| `TOBACCO_SIGNATURE` | `TABACCO_STATUS` | Direct match |
+| `TEMOZOLOMIDE_SIGNATURE` | `TEMOZOLOMIDE_STATUS` | Direct match |
+| `UVA_SIGNATURE` | `UVA_STATUS` | Direct match |
+| `FUSION_PARTNER_HUGO_SYMBOL` | `FUSION_PARTNER_HUGO_SYMBOL` | Direct match |
+| `DISPLAY_NAME` | *(ignored)* | — |
+
+### Special Matching Logic (plugins)
+
+Beyond the config, DFCI-specific plugins apply additional transforms:
+
+- **`DFCIQueryNodeTransformer.py`** — rewrites SV queries: if a trial has `STRUCTURAL_VARIANT_COMMENT` but no structured SV partner gene, it converts to a regex search of the free-text comment field.
+- **`DFCIMatchCriteriaTranform.py`** — handles age date-integer conversion, OncoTree hierarchy expansion, TMB range queries, and variant category / CNV / MMR value mapping.
+- **`DFCITrialMatchDocumentCreator.py`** — post-processes results: if any match reason for a patient is `show_in_ui=False`, all reasons for that patient are flipped to `False` (all-or-nothing per patient).
+
+---
+
+## 4. Match Output — `trial_match` Collection Fields
+
+Each document represents one **patient × trial arm × genomic alteration** match.
+
+### Patient Identity
+
+| Field | Description |
+|---|---|
+| `sample_id` | Patient sample ID (from `clinical.SAMPLE_ID`) |
+| `mrn` | Patient MRN |
+| `clinical_id` | MongoDB `_id` of the matching `clinical` document |
+| `genomic_id` | MongoDB `_id` of the matching `genomic` document |
+
+### Patient Clinical Data (denormalized from `clinical`)
+
+| Field | Description |
+|---|---|
+| `gender` | Patient gender |
+| `vital_status` | `"alive"` or `"deceased"` |
+| `oncotree_primary_diagnosis_name` | Patient's cancer diagnosis |
+| `report_date` | Genomic report date |
+
+### Genomic Alteration (denormalized from `genomic`)
+
+| Field | Description |
+|---|---|
+| `genomic_alteration` | Human-readable alteration string, e.g. `"EGFR p.E746_A750del"` |
+| `true_hugo_symbol` | Gene name |
+| `true_protein_change` | Protein change |
+| `true_cdna_change` | cDNA change |
+| `true_variant_classification` | Variant classification |
+| `true_transcript_exon` | Exon number |
+| `variant_category` | `MUTATION`, `CNV`, or `SV` |
+| `cnv_call` | CNV call if applicable |
+| `wildtype` | Boolean |
+| `allele_fraction` | Variant allele fraction |
+| `reference_allele` | Reference allele |
+| `tier` | Variant tier (1–4; 0 = untiered) |
+| `chromosome` | Chromosome |
+| `position` | Genomic position |
+| `actionability` | Actionability annotation |
+| `mmr_status` | MMR/MSI status |
+
+### Trial Identity
+
+| Field | Description |
+|---|---|
+| `protocol_no` | Trial protocol number |
+| `internal_id` | Internal ID of the matched arm/step/dose level |
+| `code` | Human-readable arm/step code (e.g. `"ARM 1"`) |
+
+### Match Mechanics
+
+| Field | Description |
+|---|---|
+| `match_level` | Where in the CTML hierarchy the match occurred: `"arm"`, `"step"`, or `"dose"` |
+| `match_path` | Dot-path to the CTML node that matched, e.g. `"treatment_list.step.0.arm.0.match"` |
+| `match_type` | What genomic feature drove the match: `"variant"` (exact protein change), `"gene"` (gene-level), `"mmr"`, `"tmb"`, etc. |
+| `reason_type` | `"genomic"` or `"clinical"` — which collection provided the match reason |
+| `cancer_type_match` | `"specific"`, `"all_solid"`, or `"all_liquid"` — how specific the oncotree diagnosis match was |
+| `combo_coord` | SHA1 hash identifying the specific combination of criteria nodes that matched (the path through the match tree) |
+| `query_hash` | Hash of the raw MongoDB query that produced this match |
+
+### Trial Status
+
+| Field | Description |
+|---|---|
+| `trial_curation_level_status` | Status of the matched arm/dose level: `"open"` or `"closed"` |
+| `trial_summary_status` | Overall trial status: `"open"` or `"closed"` |
+| `coordinating_center` | Trial coordinating center (e.g. `"Dana-Farber Cancer Institute"`) |
+| `is_disabled` | Boolean — suppressed from results |
+
+### UI / Display
+
+| Field | Description |
+|---|---|
+| `show_in_ui` | Boolean — whether this match should be surfaced in the MatchMiner UI. Set to `False` if deceased/closed; all-or-nothing per patient (see `DFCITrialMatchDocumentCreator`) |
+| `sort_order` | Array of integers used to sort matches for display, derived from `trial_match_sorting` in `dfci_config.json`. Lower = higher priority. Factors: `show_in_ui`, `trial_curation_level_status`, `match_type`, `tier`, `cnv_call`, `wildtype`, `cancer_type_match`, `coordinating_center`, `protocol_no` |
+
+### Internal / Housekeeping
+
+| Field | Description |
+|---|---|
+| `hash` | SHA1 of the full match document — used for deduplication and incremental updates |
+| `_me_id` | MatchEngine run ID that produced this document |
+| `_updated` | Timestamp of last upsert |
+| `q_depth` | Query tree depth of the match node |
+| `q_width` | Number of genomic documents that contributed to this match |
+
+---
+
+## 5. Quick Reference: Data Flow
+
+```
+dfci_config.json              oncotree_mapping.json
+     |                               |
+     v                               v
+CTML trial.match[] ──── DFCIMatchCriteriaTranform ───► MongoDB queries
+                                                            |
+                                                    clinical collection
+                                                    genomic collection
+                                                            |
+                                                            v
+                                               DFCIQueryNodeTransformer
+                                               (SV rewrite, subsetting)
+                                                            |
+                                                            v
+                                              DFCITrialMatchDocumentCreator
+                                              (show_in_ui, denormalization)
+                                                            |
+                                                            v
+                                                   trial_match collection
+```
+
+---
+
+## 6. Worked Example: Patient × Trial Match
+
+**Patient:** MRN `1035` — EGFR p.E746_A750del → Trial `10-002` ARM 1
+
+### Step 1 — The patient's documents
+
+**`clinical._id = ObjectId("5d2799d86756630d8dd065b8")`**
+```json
+{
+  "SAMPLE_ID":                       "5d2799d86756630d8dd065b8",
+  "MRN":                             "1035",
+  "GENDER":                          "Male",
+  "VITAL_STATUS":                    "alive",
+  "BIRTH_DATE":                      "1948-09-02",
+  "BIRTH_DATE_INT":                  19480901.0,
+  "ONCOTREE_PRIMARY_DIAGNOSIS_NAME": "Non-Small Cell Lung Cancer"
+}
+```
+
+**`genomic._id = ObjectId("5d279d556756630d8dda10f1")`**
+```json
+{
+  "CLINICAL_ID":              "5d2799d86756630d8dd065b8",   ← joins to clinical._id
+  "TRUE_HUGO_SYMBOL":         "EGFR",
+  "TRUE_PROTEIN_CHANGE":      "p.E746_A750del",
+  "TRUE_VARIANT_CLASSIFICATION": "In_Frame_Del",
+  "VARIANT_CATEGORY":         "MUTATION",
+  "TRUE_TRANSCRIPT_EXON":     19,
+  "WILDTYPE":                 false,
+  "ALLELE_FRACTION":          0.0,
+  "TIER":                     0
+}
+```
+
+### Step 2 — The trial's CTML criteria (ARM 1 of `10-002`)
+
+```
+treatment_list.step[0].arm[0].match  (match_path in output)
+│
+└── AND
+    ├── genomic:
+    │     hugo_symbol:             "EGFR"          → maps to TRUE_HUGO_SYMBOL
+    │     variant_classification:  "In_Frame_Del"  → maps to TRUE_VARIANT_CLASSIFICATION
+    │     variant_category:        "Mutation"      → maps to VARIANT_CATEGORY (via variant_category_map)
+    │
+    └── clinical:
+          age_numerical:              ">=18"        → maps to BIRTH_DATE_INT (age_range_to_date_int_query)
+          oncotree_primary_diagnosis: "Non-Small Cell Lung Cancer"
+                                                   → maps to ONCOTREE_PRIMARY_DIAGNOSIS_NAME (via oncotree_mapping.json)
+```
+
+All key→field translations are defined in `dfci_config.json → ctml_collection_mappings`.
+
+### Step 3 — How each criterion is evaluated
+
+| CTML criterion | Patient value | Pass? | Notes |
+|---|---|---|---|
+| `hugo_symbol = "EGFR"` | `TRUE_HUGO_SYMBOL = "EGFR"` | ✓ | Direct string match |
+| `variant_classification = "In_Frame_Del"` | `TRUE_VARIANT_CLASSIFICATION = "In_Frame_Del"` | ✓ | Direct string match |
+| `variant_category = "Mutation"` | `VARIANT_CATEGORY = "MUTATION"` | ✓ | `variant_category_map` normalizes case |
+| `age_numerical >= 18` | `BIRTH_DATE_INT = 19480901` → age ~77 | ✓ | Converted to date integer range query |
+| `oncotree_primary_diagnosis = "Non-Small Cell Lung Cancer"` | `ONCOTREE_PRIMARY_DIAGNOSIS_NAME = "Non-Small Cell Lung Cancer"` | ✓ | `oncotree_mapping.json` expands to all subtypes; exact match here |
+
+Because this is an `AND` block, **all five must pass** — they do.
+
+Note: the match hits at the **gene level** (hugo_symbol + variant_classification), not the **variant level** (exact protein change). The trial doesn't specify `protein_change`, so any EGFR In_Frame_Del qualifies. This is why `match_type = "gene"` in the output, not `"variant"`.
+
+### Step 4 — The resulting `trial_match` document
+
+```json
+{
+  "sample_id":    "5d2799d86756630d8dd065b8",   ← from clinical.SAMPLE_ID
+  "clinical_id":  "5d2799d86756630d8dd065b8",   ← clinical._id
+  "genomic_id":   "5d279d556756630d8dda10f1",   ← genomic._id of the matching alteration
+  "mrn":          "1035",
+  "protocol_no":  "10-002",                      ← links back to trial.protocol_no
+  "internal_id":  211,                           ← arm_internal_id from CTML
+  "code":         "ARM 1",
+
+  "match_level":  "arm",                         ← which CTML level matched
+  "match_path":   "treatment_list.step.0.arm.0.match",
+  "match_type":   "gene",                        ← gene-level, not exact protein change
+  "reason_type":  "genomic",                     ← genomic doc drove the match
+  "cancer_type_match": "specific",               ← diagnosis matched a specific OncoTree node
+
+  "genomic_alteration":        "EGFR p.E746_A750del",
+  "true_hugo_symbol":          "EGFR",
+  "true_protein_change":       "p.E746_A750del",
+  "true_variant_classification": "In_Frame_Del",
+  "variant_category":          "MUTATION",
+  "true_transcript_exon":      19,
+  "wildtype":                  false,
+
+  "oncotree_primary_diagnosis_name": "Non-Small Cell Lung Cancer",
+  "gender":        "Male",
+  "vital_status":  "alive",
+
+  "trial_curation_level_status": "open",
+  "trial_summary_status":        "open",
+  "show_in_ui":    true,
+  "sort_order":    [1, 99, 1, 99, 99, 99, 10002]
+}
+```
+
+### Document relationships at a glance
+
+```
+clinical._id  ──────────────────────────────────► trial_match.clinical_id
+clinical._id  ◄── genomic.CLINICAL_ID
+genomic._id   ──────────────────────────────────► trial_match.genomic_id
+trial.protocol_no ──────────────────────────────► trial_match.protocol_no
+trial.treatment_list.step[0].arm[0].arm_internal_id → trial_match.internal_id
+```

--- a/matchengine/internals/database_connectivity/mongo_connection.py
+++ b/matchengine/internals/database_connectivity/mongo_connection.py
@@ -68,7 +68,7 @@ class MongoDBConnection(object):
 
         if not hasattr(self, 'secrets'):
             self.secrets = DefaultDBSecrets().get_secrets()
-        self.db = db if db is not None else self.secrets.DB
+        self.db = db if db else self.secrets.DB
 
     def __enter__(self):
         username = self.secrets.RO_USERNAME if self.read_only else self.secrets.RW_USERNAME

--- a/matchengine/internals/engine.py
+++ b/matchengine/internals/engine.py
@@ -108,15 +108,17 @@ class MatchEngine(object):
     def __exit__(self, exception_type, exception_value, exception_traceback):
         """
         Teardown database connections (async + synchronous) and async workers gracefully.
+        Workers must be drained before connections are closed, otherwise in-flight tasks
+        will attempt to use a closed motor client and raise InvalidOperation.
         """
-        if self.db_init:
-            self._async_db_ro.__exit__(exception_type, exception_value, exception_traceback)
-            self._async_db_rw.__exit__(exception_type, exception_value, exception_traceback)
-            self._db_ro.__exit__(exception_type, exception_value, exception_traceback)
         if not self.loop.is_closed():
             self._loop.run_until_complete(self._async_exit())
             self._loop.stop()
             self._loop.close()
+        if self.db_init:
+            self._async_db_ro.__exit__(exception_type, exception_value, exception_traceback)
+            self._async_db_rw.__exit__(exception_type, exception_value, exception_traceback)
+            self._db_ro.__exit__(exception_type, exception_value, exception_traceback)
 
     def __init__(
             self,
@@ -194,6 +196,7 @@ class MatchEngine(object):
         log.info(f"Connected to database {self.db_ro.name}")
         # TODO: check how this flag works with run log
         self._drop = drop
+
         if self._drop:
             log.info((f"Dropping all matches"
                       "\n\t"
@@ -261,6 +264,7 @@ class MatchEngine(object):
             asyncio.set_event_loop(self._loop)
 
         self._loop.run_until_complete(self._async_init(db_name))
+        log.info("Finished asynchronous initialization")
 
 
     def check_run_log_flags(self,
@@ -466,6 +470,7 @@ class MatchEngine(object):
                     self.task_q.put_nowait(UpdateTask([UpdateMany(query, update)],
                                                       protocol_number))
             self.update_matches_for_protocol_number(protocol_number)
+        self._loop.run_until_complete(self._task_q.join())
 
     def get_matches_for_all_trials(self) -> Dict[str, Dict[str, List]]:
         """
@@ -967,7 +972,7 @@ class MatchEngine(object):
         if protocol_nos is None and sample_ids is None:
             self.db_rw.get_collection(self.trial_match_collection).drop()
         else:
-            self.db_rw.get_collection(self.trial_match_collection).remove(drop_query)
+            self.db_rw.get_collection(self.trial_match_collection).delete_many(drop_query)
 
     @property
     def trials_to_match_on(self):

--- a/matchengine/internals/load.py
+++ b/matchengine/internals/load.py
@@ -31,21 +31,24 @@ def load(args: Namespace):
     with ExitStack() as stack:
         db_rw = stack.enter_context(MongoDBConnection(read_only=False, db=args.db_name, async_init=False))
         db_ro = stack.enter_context(MongoDBConnection(read_only=True, db=args.db_name, async_init=False))
-        log.info(f"Database: {args.db_name}")
+        log.info(f"Database (args): {args.db_name!r} | Database (actual connection): {db_rw.name!r}")
         if args.trial:
             log.info('Adding trial(s) to mongo...')
-            load_trials(db_rw, args)
+            count = load_trials(db_rw, args)
+            log.info(f'Loaded {count} document(s) into the trial collection.')
 
         if args.clinical:
             log.info('Adding clinical data to mongo...')
-            load_clinical(db_rw, args)
+            count = load_clinical(db_rw, args)
+            log.info(f'Loaded {count} document(s) into the clinical collection.')
 
         if args.genomic:
             if len(list(db_ro.clinical.find({}))) == 0:
                 log.warning("No clinical documents in db. Please load clinical documents before loading genomic.")
 
             log.info('Adding genomic data to mongo...')
-            load_genomic(db_rw, db_ro, args)
+            count = load_genomic(db_rw, db_ro, args)
+            log.info(f'Loaded {count} document(s) into the genomic collection.')
 
         log.info('Done.')
 
@@ -55,30 +58,32 @@ def load(args: Namespace):
 #################
 def load_trials(db_rw, args: Namespace):
     if args.trial_format == 'json':
-        load_trials_json(args, db_rw)
+        return load_trials_json(args, db_rw)
     elif args.trial_format == 'yaml':
-        load_trials_yaml(args, db_rw)
+        return load_trials_yaml(args, db_rw)
+    return 0
 
 
 def load_trials_yaml(args: Namespace, db_rw):
     if os.path.isdir(args.trial):
-        load_dir(args, db_rw, "yaml", args.trial, 'trial')
+        return load_dir(args, db_rw, "yaml", args.trial, 'trial')
     else:
-        load_file(db_rw, 'yaml', args.trial, 'trial')
+        return load_file(db_rw, 'yaml', args.trial, 'trial')
 
 
 def load_trials_json(args: Namespace, db_rw):
     # load a directory of json files
     if os.path.isdir(args.trial):
-        load_dir(args, db_rw, "json", args.trial, 'trial')
+        return load_dir(args, db_rw, "json", args.trial, 'trial')
     else:
         # path leads to a single JSON file
         if is_valid_single_json(args.trial):
-            load_file(db_rw, 'json', args.trial, 'trial')
+            return load_file(db_rw, 'json', args.trial, 'trial')
 
         else:
             with open(args.trial) as file:
                 json_raw = file.read()
+                count = 0
                 success = None
                 try:
                     # mongoexport by default exports each object on a new line
@@ -86,6 +91,7 @@ def load_trials_json(args: Namespace, db_rw):
                     for doc in json_array:
                         data = json.loads(doc)
                         db_rw.trial.insert_one(data)
+                        count += 1
                     success = True
                 except json.decoder.JSONDecodeError as e:
                     log.debug(f"{e}")
@@ -95,6 +101,7 @@ def load_trials_json(args: Namespace, db_rw):
                         json_array = json.loads(json_raw)
                         for doc in json_array:
                             db_rw.trial.insert_one(doc)
+                            count += 1
                         success = True
                     except json.decoder.JSONDecodeError as e:
                         log.debug(f"{e}")
@@ -103,6 +110,7 @@ def load_trials_json(args: Namespace, db_rw):
                                 'Cannot read json format. JSON documents must be either newline separated, '
                                 'in an array, or loaded as separate documents ')
                             raise Exception("Unknown JSON Format")
+                return count
 
 
 ########################
@@ -110,28 +118,28 @@ def load_trials_json(args: Namespace, db_rw):
 ########################
 def load_clinical(db_rw, args: Namespace):
     if args.patient_format == 'json':
-
-        # load directory of clinical json files
         if os.path.isdir(args.clinical):
-            load_dir(args, db_rw, 'json', args.clinical, 'clinical')
+            return load_dir(args, db_rw, 'json', args.clinical, 'clinical')
         else:
-            load_file(db_rw, 'json', args.clinical, 'clinical')
-
+            return load_file(db_rw, 'json', args.clinical, 'clinical')
     elif args.patient_format == 'csv':
-        load_file(db_rw, 'csv', args.clinical, 'clinical')
+        return load_file(db_rw, 'csv', args.clinical, 'clinical')
+    return 0
 
 
-def load_genomic(db_rw, db_ro, args: Namespace, ):
+def load_genomic(db_rw, db_ro, args: Namespace):
     if args.patient_format == 'json':
-        # load directory of clinical json files
         if os.path.isdir(args.genomic):
-            load_dir(args, db_rw, 'json', args.genomic, 'genomic')
+            count = load_dir(args, db_rw, 'json', args.genomic, 'genomic')
         else:
-            load_file(db_rw, 'json', args.genomic, 'genomic')
+            count = load_file(db_rw, 'json', args.genomic, 'genomic')
     elif args.patient_format == 'csv':
-        load_file(db_rw, 'csv', args.genomic, 'genomic')
+        count = load_file(db_rw, 'csv', args.genomic, 'genomic')
+    else:
+        count = 0
 
     map_clinical_to_genomic(db_rw, db_ro)
+    return count
 
 
 def map_clinical_to_genomic(db_rw, db_ro):
@@ -153,14 +161,17 @@ def map_clinical_to_genomic(db_rw, db_ro):
 # util functions
 ##################
 def load_dir(args: Namespace, db_rw, filetype: str, path: str, collection: str):
+    count = 0
     for filename in os.listdir(path):
         if filename.endswith(f".{filetype}"):
             val = vars(args)[collection]
             full_path = val + filename if val[-1] == '/' else val + '/' + filename
-            load_file(db_rw, filetype, full_path, collection)
+            count += load_file(db_rw, filetype, full_path, collection)
+    return count
 
 
 def load_file(db_rw, filetype: str, path: str, collection: str):
+    count = 0
     with open(path) as file_handle:
         if filetype == 'csv':
             file_handle = csv.DictReader(file_handle, delimiter=',')
@@ -170,11 +181,13 @@ def load_file(db_rw, filetype: str, path: str, collection: str):
                         row[key] = convert_birthdate(row[key])
                         row['BIRTH_DATE_INT'] = int(row[key].strftime('%Y%m%d'))
                 db_rw[collection].insert_one(row)
+                count += 1
         else:
             raw_file_data = file_handle.read()
             if filetype == 'yaml':
-                data = yaml.safe_load_all(raw_file_data)
+                data = list(yaml.safe_load_all(raw_file_data))
                 db_rw[collection].insert_many(data)
+                count = len(data)
             elif filetype == 'json':
                 if is_valid_single_json(path):
                     data = json_util.loads(raw_file_data)
@@ -183,6 +196,8 @@ def load_file(db_rw, filetype: str, path: str, collection: str):
                             data[key] = convert_birthdate(data[key])
                             data['BIRTH_DATE_INT'] = int(data[key].strftime('%Y%m%d'))
                     db_rw[collection].insert_one(data)
+                    count = 1
+    return count
 
 
 def convert_birthdate(birth_date):

--- a/matchengine/main.py
+++ b/matchengine/main.py
@@ -71,13 +71,13 @@ def run_cli():
     subp_p = subp.add_parser('load', help='Sets up your MongoDB for matching.')
     subp_p.add_argument('-t', dest='trial', default=None, help=param_trials_help)
     subp_p.add_argument('-c', dest='clinical', default=None, help=param_clinical_help)
-    subp_p.add_argument('-g', dest='extended_attributes', default=None, help=param_genomic_help)
+    subp_p.add_argument('-g', dest='genomic', default=None, help=param_genomic_help)
     subp_p.add_argument('--trial-format', dest='trial_format', default='json', action='store', choices=['yml', 'json'],
                         help=param_trial_format_help)
     subp_p.add_argument('--patient-format', dest='patient_format', default='json', action='store',
                         choices=['csv', 'json'],
                         help=param_patient_format_help)
-    subp_p.add_argument('--db', dest='db_name', default='', required=False, help=db_name_help)
+    subp_p.add_argument('--db', dest='db_name', default=None, required=False, help=db_name_help)
     subp_p.add_argument("--plugin-dir", dest="plugin_dir",
                         default=os.path.join(base_dir, "plugins"), help="Location of plugin directory")
     subp_p.set_defaults(func=load)

--- a/matchengine/tests/test_matchengine_integration.py
+++ b/matchengine/tests/test_matchengine_integration.py
@@ -32,12 +32,12 @@ class IntegrationTestMatchengine(TestCase):
             assert setup_db.name == 'integration'
 
             if not kwargs.get("skip_sample_id_reset", False):
-                setup_db.clinical.update({"SAMPLE_ID": "5d2799d86756630d8dd065b8"},
+                setup_db.clinical.update_one({"SAMPLE_ID": "5d2799d86756630d8dd065b8"},
                                          {"$set": {"ONCOTREE_PRIMARY_DIAGNOSIS_NAME": "Non-Small Cell Lung Cancer",
                                                    "_updated": datetime.datetime(2001, 1, 1, 1, 1, 1, 1)}})
 
             if not kwargs.get("skip_vital_status_reset", False):
-                setup_db.clinical.update({"SAMPLE_ID": "5d2799da6756630d8dd066a6"},
+                setup_db.clinical.update_one({"SAMPLE_ID": "5d2799da6756630d8dd066a6"},
                                          {"$set": {"VITAL_STATUS": "alive",
                                                    "_updated": datetime.datetime(2001, 1, 1, 1, 1, 1, 1)}})
 
@@ -58,7 +58,7 @@ class IntegrationTestMatchengine(TestCase):
                 for trial_path in trials_to_load:
                     with open(trial_path) as trial_file_handle:
                         trial = json.load(trial_file_handle)
-                    setup_db.trial.insert(trial)
+                    setup_db.trial.insert_one(trial)
             if kwargs.get('do_rm_clinical_run_history', False):
                 setup_db.clinical_run_history_trial_match.drop()
 
@@ -145,7 +145,7 @@ class IntegrationTestMatchengine(TestCase):
         self.me.get_matches_for_all_trials()
         for protocol_no in self.me.trials.keys():
             self.me.update_matches_for_protocol_number(protocol_no)
-        assert self.me.db_ro.trial_match.count() == 48
+        assert self.me.db_ro.trial_match.count_documents({}) == 48
 
     def test_wildcard_protein_change(self):
         self._reset(do_reset_trial_matches=True,

--- a/matchengine/tests/test_matchengine_run_log.py
+++ b/matchengine/tests/test_matchengine_run_log.py
@@ -56,12 +56,12 @@ class RunLogTest(TestCase):
             assert setup_db.name == 'integration'
 
             if not kwargs.get("skip_sample_id_reset", False):
-                setup_db.clinical.update({"SAMPLE_ID": "5d2799d86756630d8dd065b8"},
+                setup_db.clinical.update_one({"SAMPLE_ID": "5d2799d86756630d8dd065b8"},
                                          {"$set": {"ONCOTREE_PRIMARY_DIAGNOSIS_NAME": "Non-Small Cell Lung Cancer",
                                                    "_updated": datetime.datetime(2001, 1, 1, 1, 1, 1, 1)}})
 
             if not kwargs.get("skip_vital_status_reset", False):
-                setup_db.clinical.update({"SAMPLE_ID": "5d2799da6756630d8dd066a6"},
+                setup_db.clinical.update_one({"SAMPLE_ID": "5d2799da6756630d8dd066a6"},
                                          {"$set": {"VITAL_STATUS": "alive",
                                                    "_updated": datetime.datetime(2001, 1, 1, 1, 1, 1, 1)}})
 
@@ -82,7 +82,7 @@ class RunLogTest(TestCase):
                 for trial_path in trials_to_load:
                     with open(trial_path) as trial_file_handle:
                         trial = json.load(trial_file_handle)
-                    setup_db.trial.insert(trial)
+                    setup_db.trial.insert_one(trial)
             if kwargs.get('do_rm_clinical_run_history', False):
                 setup_db.clinical_run_history_trial_match.drop()
 
@@ -144,7 +144,7 @@ class RunLogTest(TestCase):
             skip_vital_status_reset=False
         )
         assert self.me.db_rw.name == 'integration'
-        self.me.db_rw.clinical.update({"SAMPLE_ID": "5d2799d86756630d8dd065b8"},
+        self.me.db_rw.clinical.update_one({"SAMPLE_ID": "5d2799d86756630d8dd065b8"},
                                       {"$set": {"ONCOTREE_PRIMARY_DIAGNOSIS_NAME": "Gibberish",
                                                 "_updated": datetime.datetime.now()}})
         self.me.get_matches_for_all_trials()
@@ -181,7 +181,7 @@ class RunLogTest(TestCase):
         assert len(run_log_trial_match) == 2
         assert len(clinical_run_history_trial_match['run_history']) == 2
         assert len(list(self.me.db_ro.trial_match.find({"clinical_id": ObjectId("5d3778bf4fbf195d68cdf4d5")}))) == 0
-        self.me.db_rw.clinical.update({"SAMPLE_ID": "5d2799d86756630d8dd065b8"},
+        self.me.db_rw.clinical.update_one({"SAMPLE_ID": "5d2799d86756630d8dd065b8"},
                                       {"$set": {"ONCOTREE_PRIMARY_DIAGNOSIS_NAME": "Lung Adenocarcinoma",
                                                 "_updated": datetime.datetime(2002, 1, 1, 1, 1, 1, 1)}})
 
@@ -229,7 +229,7 @@ class RunLogTest(TestCase):
             report_all_clinical=False
         )
         assert self.me.db_rw.name == 'integration'
-        self.me.db_rw.clinical.update({"SAMPLE_ID": "5d2799d86756630d8dd065b8"},
+        self.me.db_rw.clinical.update_one({"SAMPLE_ID": "5d2799d86756630d8dd065b8"},
                                       {"$set": {"ONCOTREE_PRIMARY_DIAGNOSIS_NAME": "Gibberish",
                                                 "_updated": datetime.datetime.now()}})
         self.me.get_matches_for_all_trials()
@@ -241,7 +241,7 @@ class RunLogTest(TestCase):
         assert len(trial_matches) == 0
         assert len(run_log_trial_match) == 1
         assert len(clinical_run_history_trial_match) == 1392
-        self.me.db_rw.clinical.update({"SAMPLE_ID": "5d2799d86756630d8dd065b8"},
+        self.me.db_rw.clinical.update_one({"SAMPLE_ID": "5d2799d86756630d8dd065b8"},
                                       {"$set": {"ONCOTREE_PRIMARY_DIAGNOSIS_NAME": "Medullary Carcinoma of the Colon",
                                                 "_updated": datetime.datetime(2002, 1, 1, 1, 1, 1, 1)}})
 
@@ -316,7 +316,7 @@ class RunLogTest(TestCase):
             report_all_clinical=False
         )
         assert self.me.db_rw.name == 'integration'
-        self.me.db_rw.clinical.update({"SAMPLE_ID": "5d2799d86756630d8dd065b8"},
+        self.me.db_rw.clinical.update_one({"SAMPLE_ID": "5d2799d86756630d8dd065b8"},
                                       {"$set": {"ONCOTREE_PRIMARY_DIAGNOSIS_NAME": "Gibberish",
                                                 "_updated": datetime.datetime.now()}})
         self.me.get_matches_for_all_trials()
@@ -364,7 +364,7 @@ class RunLogTest(TestCase):
             report_all_clinical=False,
             skip_sample_id_reset=False
         )
-        self.me.db_rw.clinical.update({"SAMPLE_ID": "5d2799d86756630d8dd065b8"},
+        self.me.db_rw.clinical.update_one({"SAMPLE_ID": "5d2799d86756630d8dd065b8"},
                                       {"$set": {"ONCOTREE_PRIMARY_DIAGNOSIS_NAME": "Gibberish",
                                                 "_updated": datetime.datetime(2002, 1, 1, 1, 1, 1, 1)}})
 
@@ -424,7 +424,7 @@ class RunLogTest(TestCase):
             skip_sample_id_reset=False
         )
 
-        self.me.db_rw.trial.update({"protocol_no": "10-007"},
+        self.me.db_rw.trial.update_one({"protocol_no": "10-007"},
                                    {"$set": {"unused_field": "ricky_bobby",
                                              "_updated": datetime.datetime(2002, 1, 1, 1, 1, 1, 1)
                                              }})
@@ -484,17 +484,17 @@ class RunLogTest(TestCase):
             skip_sample_id_reset=False
         )
 
-        self.me.db_rw.trial.update({"protocol_no": "10-007"},
+        self.me.db_rw.trial.update_one({"protocol_no": "10-007"},
                                    {"$set": {"treatment_list.step.0.arm.1.arm_suspended": "N",
                                              "_updated": datetime.datetime(2002, 1, 1, 1, 1, 1, 1)
                                              }})
         # update non-match
-        self.me.db_rw.clinical.update({"SAMPLE_ID": "5d2799df6756630d8dd068bb"},
+        self.me.db_rw.clinical.update_one({"SAMPLE_ID": "5d2799df6756630d8dd068bb"},
                                       {"$set": {"ONCOTREE_PRIMARY_DIAGNOSIS_NAME": "Gibberish",
                                                 "_updated": datetime.datetime.now()}})
 
         # update matching
-        self.me.db_rw.genomic.insert({
+        self.me.db_rw.genomic.insert_one({
             "SAMPLE_ID": "5d2799da6756630d8dd066a6",
             "clinical_id": ObjectId("5d2799da6756630d8dd066a6"),
             "_updated": datetime.datetime(2002, 1, 1, 1, 1, 1, 1),
@@ -515,7 +515,7 @@ class RunLogTest(TestCase):
         assert len(run_log_trial_match) == 2
         assert len(non_match) == 0
 
-        self.me.db_rw.genomic.remove({"TRUE_HUGO_SYMBOL": "sonic_the_hedgehog"})
+        self.me.db_rw.genomic.delete_many({"TRUE_HUGO_SYMBOL": "sonic_the_hedgehog"})
 
     def test_run_log_6(self):
         """
@@ -557,12 +557,12 @@ class RunLogTest(TestCase):
             skip_sample_id_reset=False
         )
 
-        self.me.db_rw.trial.update({"protocol_no": "10-007"},
+        self.me.db_rw.trial.update_one({"protocol_no": "10-007"},
                                    {"$set": {"treatment_list.step.0.arm.1.arm_suspended": "N",
                                              "_updated": datetime.datetime(2002, 1, 1, 1, 1, 1, 1)
                                              }})
 
-        self.me.db_rw.clinical.update({"SAMPLE_ID": "5d2799da6756630d8dd066a6"},
+        self.me.db_rw.clinical.update_one({"SAMPLE_ID": "5d2799da6756630d8dd066a6"},
                                       {"$set": {"VITAL_STATUS": "deceased",
                                                 "_updated": datetime.datetime(2002, 1, 1, 1, 1, 1, 1)
                                                 }})
@@ -590,7 +590,7 @@ class RunLogTest(TestCase):
             skip_sample_id_reset=False
         )
 
-        self.me.db_rw.trial.update({"protocol_no": "10-007"},
+        self.me.db_rw.trial.update_one({"protocol_no": "10-007"},
                                    {"$set": {"unused_field": "ricky_bobby",
                                              "_updated": datetime.datetime(2002, 2, 1, 1, 1, 1, 1)
                                              }})
@@ -646,11 +646,11 @@ class RunLogTest(TestCase):
             skip_sample_id_reset=False
         )
 
-        self.me.db_rw.trial.update({"protocol_no": "10-007"},
+        self.me.db_rw.trial.update_one({"protocol_no": "10-007"},
                                    {"$set": {"treatment_list.step.0.arm.0.match.0.and.0.hugo_symbol": "BRAF",
                                              "_updated": datetime.datetime(2002, 1, 1, 1, 1, 1, 1)}})
 
-        self.me.db_rw.clinical.update({"SAMPLE_ID": "5d2799da6756630d8dd066a6"},
+        self.me.db_rw.clinical.update_one({"SAMPLE_ID": "5d2799da6756630d8dd066a6"},
                                       {"$set": {"VITAL_STATUS": "deceased",
                                                 "_updated": datetime.datetime(2002, 1, 1, 1, 1, 1, 1)}})
 
@@ -697,7 +697,7 @@ class RunLogTest(TestCase):
         assert len(disabled_trial_matches) == 0
         assert len(run_log_trial_match) == 1
 
-        self.me.db_rw.clinical.update({"SAMPLE_ID": "5d2799da6756630d8dd066a6"},
+        self.me.db_rw.clinical.update_one({"SAMPLE_ID": "5d2799da6756630d8dd066a6"},
                                       {"$set": {"VITAL_STATUS": "deceased",
                                                 "_updated": datetime.datetime(2002, 2, 1, 1, 1, 1, 1)}})
 
@@ -727,7 +727,7 @@ class RunLogTest(TestCase):
         assert len(disabled_trial_matches) == 2
         assert len(run_log_trial_match) == 2
 
-        self.me.db_rw.clinical.update({"SAMPLE_ID": "5d2799da6756630d8dd066a6"},
+        self.me.db_rw.clinical.update_one({"SAMPLE_ID": "5d2799da6756630d8dd066a6"},
                                       {"$set": {"VITAL_STATUS": "alive",
                                                 "_updated": datetime.datetime(2002, 2, 1, 1, 1, 1, 1)}})
 
@@ -764,7 +764,7 @@ class RunLogTest(TestCase):
         assert len(no_match) == 0
         assert len(known_match) == 0
 
-        self.me.db_rw.trial.update({"protocol_no": "10-001"},
+        self.me.db_rw.trial.update_one({"protocol_no": "10-001"},
                                    {"$set": {"treatment_list.step.0.arm.0.arm_suspended": "N",
                                              "_updated": datetime.datetime(2002, 1, 1, 1, 1, 1, 1)
                                              }})
@@ -825,7 +825,7 @@ class RunLogTest(TestCase):
         assert len(run_log_trial_match) == 1
         assert len(no_match) == 0
 
-        self.me.db_rw.trial.update({"protocol_no": "10-001"},
+        self.me.db_rw.trial.update_one({"protocol_no": "10-001"},
                                    {"$set": {"unused_field": "ricky_bobby",
                                              "_updated": datetime.datetime(2002, 1, 1, 1, 1, 1, 1)
                                              }})
@@ -879,7 +879,7 @@ class RunLogTest(TestCase):
         assert len(no_match) == 0
         assert len(run_log_trial_match) == 1
 
-        self.me.db_rw.clinical.update({"SAMPLE_ID": "5d2799da6756630d8dd066a6"},
+        self.me.db_rw.clinical.update_one({"SAMPLE_ID": "5d2799da6756630d8dd066a6"},
                                       {"$set": {"VITAL_STATUS": "deceased",
                                                 "_updated": datetime.datetime(2002, 2, 1, 1, 1, 1, 1)}})
 

--- a/setup.py
+++ b/setup.py
@@ -20,9 +20,9 @@ setup(
     install_requires=[
         "python-dateutil>=2.8.0",
         "PyYAML>=5.1",
-        "pymongo>=3.8.0,<4",
+        "pymongo>=4.0",
         "networkx>=2.3",
-        "motor==2.0.0"
+        "motor>=3.0.0"
     ],
     include_package_data=True,
     python_requires='>=3.7',


### PR DESCRIPTION
# start here
- Fixed -g CLI argument destination from extended_attributes to genomic so genomic loading actually works from the command line
- Fixed --db default from '' to None so an empty string no longer overrides the secrets-configured database name
- Refactored all load_* functions to return document counts and added log.info feedback after each load step (e.g. Loaded 12 document(s) into the clinical collection.)
- Improved DB connection logging to show both the arg value and the actual connected database name for easier debugging
- Added MATCHENGINE_DATA_REFERENCE.md — a reference doc covering patient/trial data locations, CTML matching criteria, config field mappings, and a full annotated worked example of a patient-trial match